### PR TITLE
イベントの参加依頼をイベント関係者からのみ見えるようにする

### DIFF
--- a/Vche-rails/app/loyalties/events/event_follow_requests_loyalty.rb
+++ b/Vche-rails/app/loyalties/events/event_follow_requests_loyalty.rb
@@ -1,6 +1,6 @@
 class Events::EventFollowRequestsLoyalty < ApplicationLoyalty
   def index?
-    true || LoyaltyTools.user_is_backstage_member?(record, user)
+    LoyaltyTools.user_is_backstage_member?(record, user)
   end
 
   def withdraw?


### PR DESCRIPTION
Close #48

イベントの参加依頼を部外者が取り下げられたわけでもない ~~し、まだ誰も使ってない~~ ので別にいいでしょうという気持ち