### PR TITLE
開催日時の変更を専用のアクションで行うようにした

### DIFF
--- a/Vche-rails/app/controllers/events/event_histories/reschedules_controller.rb
+++ b/Vche-rails/app/controllers/events/event_histories/reschedules_controller.rb
@@ -1,0 +1,33 @@
+class Events::EventHistories::ReschedulesController < ApplicationController::Bootstrap
+  before_action :find_parent_event
+  before_action :find_parent_event_history
+
+  def new
+    authorize! @event_history
+    @user = current_user
+  end
+
+  def create
+    authorize! @event_history
+    @new_event_history = Operations::EventHistory::Reschedule.new(event_history: @event_history, params: reschedule_params, user: current_user).perform!
+    redirect_to [@event, @new_event_history], notice: I18n.t('notice.events/event_histories/reschedules.create.success')
+  rescue Operations::EventHistory::Reschedule::Unchanged
+    redirect_to [@event, @event_history], notice: I18n.t('notice.events/event_histories/reschedules.create.unchanged')
+  end
+
+  private
+
+  def find_parent_event
+    @event = Event.friendly.find(params[:event_id])
+  end
+
+  def find_parent_event_history
+    @event_history = @event.find_or_build_history(Time.zone.parse(params[:event_history_id]))
+  end
+
+  def reschedule_params
+    params.require(:event_history).permit(
+      :capacity,
+      :assembled_at, :opened_at, :started_at, :ended_at, :closed_at)
+  end
+end

--- a/Vche-rails/app/controllers/events/event_histories_controller.rb
+++ b/Vche-rails/app/controllers/events/event_histories_controller.rb
@@ -38,7 +38,7 @@ class Events::EventHistoriesController < ApplicationController::Bootstrap
   end
 
   def create
-    @event_history = @event.event_histories.build(event_history_params)
+    @event_history = @event.event_histories.build(create_params)
     authorize! @event_history
     @event_history.created_user = current_user
     @event_history.updated_user = current_user
@@ -54,7 +54,7 @@ class Events::EventHistoriesController < ApplicationController::Bootstrap
     @event_history = find_event_history
     authorize! @event_history
     @event_history.updated_user = current_user
-    if @event_history.update(event_history_params)
+    if @event_history.update(update_params)
       redirect_to event_event_history_path(@event, @event_history), notice: I18n.t('notice.events/event_histories.update.success')
     else
       render :edit
@@ -146,9 +146,15 @@ class Events::EventHistoriesController < ApplicationController::Bootstrap
     @event.find_or_build_history(Time.zone.parse(params[:id]))
   end
 
-  def event_history_params
-    p = params.require(:event_history).permit(
+  def create_params
+    params.require(:event_history).permit(
       :resolution, :capacity, :default_audience_role,
       :assembled_at, :opened_at, :started_at, :ended_at, :closed_at)
+  end
+
+  def update_params
+    params.require(:event_history).permit(
+      :resolution, :capacity, :default_audience_role,
+      :assembled_at, :opened_at, :ended_at, :closed_at)
   end
 end

--- a/Vche-rails/app/loyalties/events/event_histories/reschedules_loyalty.rb
+++ b/Vche-rails/app/loyalties/events/event_histories/reschedules_loyalty.rb
@@ -1,0 +1,5 @@
+class Events::EventHistories::ReschedulesLoyalty < ApplicationLoyalty
+  def create?
+    LoyaltyTools.user_is_source?(record.event, user)
+  end
+end

--- a/Vche-rails/app/models/operations/event_history/Reschedule.rb
+++ b/Vche-rails/app/models/operations/event_history/Reschedule.rb
@@ -1,0 +1,32 @@
+class Operations::EventHistory::Reschedule < Operations::Operation
+  class Unchanged < StandardError; end
+
+  def initialize(event_history:, params:, user:)
+    @event_history = event_history
+    @params = params
+    @user = user
+  end
+
+  def validate
+    raise Unchanged if event_history.started_at == started_at
+  end
+
+  def perform
+    @new_event_history = event_history.event.find_or_build_history(started_at)
+    new_event_history.assign_attributes(event_history.attributes.except('id', 'uid'))
+    new_event_history.assign_attributes(params)
+    new_event_history.created_user = user
+    new_event_history.updated_user = user
+    new_event_history.save!
+    event_history.update!(resolution: :moved)
+    new_event_history
+  end
+
+  private
+
+  attr_reader :event_history, :new_event_history, :params, :user
+
+  def started_at
+    @started_at ||= Time.zone.parse(params[:started_at])
+  end
+end

--- a/Vche-rails/app/views/event_histories/_pretty.html.slim
+++ b/Vche-rails/app/views/event_histories/_pretty.html.slim
@@ -18,7 +18,7 @@
     .field
       label = EventHistory.human_attribute_name(:opened_at)
       .value = l(event_history.opened_at) if event_history.opened_at
-  - if event_history.assembled_at
+  - if event_history.started_at
     .field
       label = EventHistory.human_attribute_name(:started_at)
       .value = l(event_history.started_at)

--- a/Vche-rails/app/views/event_histories/_strip.html.slim
+++ b/Vche-rails/app/views/event_histories/_strip.html.slim
@@ -32,3 +32,6 @@
           = render 'events/event_histories/resolutions/quick_inline_forms', event: event, event_history: event_history
         - if loyalty(event_history, 'events/event_histories/resolutions').edit?
           = link_to '状態を変更する', edit_event_event_history_resolution_path(event, event_history), class: 'button'
+        - if loyalty(event_history, 'events/event_histories/reschedules').new?
+          = link_to '日程を変更する', new_event_event_history_reschedule_path(event, event_history), class: 'button'
+

--- a/Vche-rails/app/views/events/event_histories/_form.html.slim
+++ b/Vche-rails/app/views/events/event_histories/_form.html.slim
@@ -14,8 +14,12 @@
 
   = render_field form, :opened_at do
     = form.datetime_field :opened_at
-  = render_field form, :started_at, required: true do
-    = form.datetime_field :started_at
+  - if event_history.persisted?
+    = render_field form, :started_at do
+      .value = l(event_history.started_at)
+  - else
+    = render_field form, :started_at, required: true do
+      = form.datetime_field :started_at
   = render_field form, :ended_at, required: true do
     = form.datetime_field :ended_at
 

--- a/Vche-rails/app/views/events/event_histories/reschedules/_form.html.slim
+++ b/Vche-rails/app/views/events/event_histories/reschedules/_form.html.slim
@@ -1,0 +1,29 @@
+- event ||= nil
+- event_history ||= nil
+
+= form_with(model: event_history, url: event_event_history_reschedule_path(event, event_history), method: :post, class: '-table') do |form|
+  = render_errors_header form
+
+  = render_field form, :resolution do
+    .value = event_history.resolution_emoji_text
+
+  - if loyalty(event_history, 'events/event_histories').backstage?
+    = render_field form, :assembled_at do
+      = form.datetime_field :assembled_at
+
+  = render_field form, :opened_at do
+    = form.datetime_field :opened_at
+  = render_field form, :started_at, required: true do
+    = form.datetime_field :started_at
+  = render_field form, :ended_at, required: true do
+    = form.datetime_field :ended_at
+
+  - if loyalty(event_history, 'events/event_histories').backstage?
+    = render_field form, :closed_at do
+      = form.datetime_field :closed_at
+
+  = render_text_field form, :capacity
+
+  .actions
+    - if loyalty(event_history, 'events/event_histories/reschedules').create?
+      = form.submit '日程を変更する'

--- a/Vche-rails/app/views/events/event_histories/reschedules/_help.html.slim
+++ b/Vche-rails/app/views/events/event_histories/reschedules/_help.html.slim
@@ -1,0 +1,16 @@
+.panel.-roundbox
+  p
+    | イベントの日程を変更する場合、
+    b 一部の情報のみ引き継がれます
+    | 。
+  ul
+    li
+      | 変更前の日程に今までのイベント履歴が
+      = inline_resolution_tag :moved
+      | の状態で残ります。
+      br
+      | 参加者やスタッフ登録はこちらに紐づいたまま残ります。
+    li
+      | 変更後の日程に新しいイベント履歴が
+      = inline_resolution_tag @event_history.resolution
+      | の状態で作成されます。参加者やスタッフに再度参加表明をお願いしてください。

--- a/Vche-rails/app/views/events/event_histories/reschedules/new.html.slim
+++ b/Vche-rails/app/views/events/event_histories/reschedules/new.html.slim
@@ -1,0 +1,14 @@
+h1 = "#{Event.model_name.human}の日程を変更する"
+
+= render 'events/strip', event: @event, user: @user
+
+= render 'event_histories/strip', event: @event, event_history: @event_history, user: @user
+
+= render 'help'
+
+.panel.-roundbox
+  = render 'form', event: @event, event_history: @event_history
+
+.panel
+  = link_to '戻る', [@event, @event_history], class: 'button'
+

--- a/Vche-rails/config/locales/vche.notice.ja.yml
+++ b/Vche-rails/config/locales/vche.notice.ja.yml
@@ -74,6 +74,10 @@ ja:
     users/passwords:
       update:
         success: 'パスワードを更新しました'
+    events/event_histories/reschedules:
+      create:
+        success: 'イベントの開催日時を変更しました'
+        unchanged: 'イベントの開催日時は変更されませんでした'
     events/event_histories/resolutions:
       update:
         success: 'イベントの状態を更新しました'

--- a/Vche-rails/config/routes.rb
+++ b/Vche-rails/config/routes.rb
@@ -50,6 +50,7 @@ Rails.application.routes.draw do
         post :remove_user
       end
       resource :resolution, controller: 'events/event_histories/resolutions', only: [:edit, :update]
+      resource :reschedule, controller: 'events/event_histories/reschedules', only: [:new, :create]
     end
     resources :event_follows, controller: 'events/event_follows', only: :index
     resources :event_follow_requests, controller: 'events/event_follow_requests', only: :index do


### PR DESCRIPTION
Close #18 開場日時の（正しい方法での）変更

今日のサブリソース

EventHistory は started_at で紐づけているので仕方ない話