### PR TITLE
イベント予定の削除ボタンを追加した

### DIFF
--- a/Vche-rails/app/controllers/event_schedules_controller.rb
+++ b/Vche-rails/app/controllers/event_schedules_controller.rb
@@ -52,7 +52,7 @@ class EventSchedulesController < ApplicationController::Bootstrap
     @event_schedule = find_event_schedule
     authorize! @event_schedule
     @event_schedule.destroy
-    redirect_to events_url, notice: I18n.t('notice.event_schedules.destroy.success')
+    redirect_to @event, notice: I18n.t('notice.event_schedules.destroy.success')
   end
 
   private

--- a/Vche-rails/app/views/event_schedules/_cards.html.slim
+++ b/Vche-rails/app/views/event_schedules/_cards.html.slim
@@ -17,7 +17,8 @@ div class="event_schedules -#{_layout}"
         span.start_at = start_at
         span.sep -
         span.end_at = end_at
-      - if edit && loyalty(event_schedule, :event_schedules).edit?
-        = link_to '編集する', edit_event_event_schedule_path(event, event_schedule), class: 'button'
+      - if edit
+        - if loyalty(event_schedule, :event_schedules).edit?
+          = link_to '編集する', edit_event_event_schedule_path(event, event_schedule), class: 'button'
   - if _count && _count > limit
     = "ほか #{_count - limit} 件"

--- a/Vche-rails/app/views/event_schedules/index.html.slim
+++ b/Vche-rails/app/views/event_schedules/index.html.slim
@@ -3,7 +3,7 @@ h1 = "#{Event.model_name.human}の#{EventSchedule.model_name.human}一覧"
 = render 'events/strip', event: @event, user: @user
 
 .panel
-  = render 'cards', event: @event, event_schedules: @event_schedules, edit: false, card_cloud: true
+  = render 'cards', event: @event, event_schedules: @event_schedules, edit: true, card_cloud: true
 .panel
   = paginate @event_schedules
 

--- a/Vche-rails/app/views/event_schedules/show.html.slim
+++ b/Vche-rails/app/views/event_schedules/show.html.slim
@@ -30,5 +30,7 @@ h1 = "#{EventSchedule.model_name.human}詳細"
   .actions
     - if loyalty(@event_schedule).edit?
       = link_to '編集する', edit_event_event_schedule_path(@event, @event_schedule), class: 'button'
+    - if loyalty(@event_schedule).destroy?
+      = link_to '削除する', event_event_schedule_path(@event, @event_schedule), method: :delete, class: 'button -negative'
 
   = render 'editor_info', resource: @event_schedule


### PR DESCRIPTION
Fix #67 

<img width="687" alt="image" src="https://user-images.githubusercontent.com/4142423/143028878-d9b2ba40-5879-4f1a-8f46-9ad466278fd8.png">

機能としては存在していた