### PR TITLE
イベントの開催回を削除できるようにした

### DIFF
--- a/Vche-rails/app/controllers/events/event_histories_controller.rb
+++ b/Vche-rails/app/controllers/events/event_histories_controller.rb
@@ -65,7 +65,7 @@ class Events::EventHistoriesController < ApplicationController::Bootstrap
     @event_history = find_event_history
     authorize! @event_history
     @event_history.destroy
-    redirect_to events_url, notice: I18n.t('notice.events/event_histories.destroy.success')
+    redirect_to event_event_history_path(@event, @event_history), notice: I18n.t('notice.events/event_histories.destroy.success')
   end
 
   def attend

--- a/Vche-rails/app/javascript/stylesheets/models/_calendar.scss
+++ b/Vche-rails/app/javascript/stylesheets/models/_calendar.scss
@@ -153,6 +153,13 @@
           content: '📗';
         }
       }
+      &.-resolution_phantom {
+        background: $disabled_bg-light;
+        color: $negative_text;
+        .entry::before {
+          content: '🗑';
+        }
+      }
       &.-masked {
         font-style: oblique;
       }

--- a/Vche-rails/app/loyalties/events/event_histories/event_attendances_loyalty.rb
+++ b/Vche-rails/app/loyalties/events/event_histories/event_attendances_loyalty.rb
@@ -1,5 +1,5 @@
 class Events::EventHistories::EventAttendancesLoyalty < ApplicationLoyalty
   def index?
-    LoyaltyTools.event_accessible?(record.event, user)
+    LoyaltyTools.event_accessible?(record.event, user) && !record.resolution.phantom?
   end
 end

--- a/Vche-rails/app/loyalties/events/event_histories/event_attendances_loyalty.rb
+++ b/Vche-rails/app/loyalties/events/event_histories/event_attendances_loyalty.rb
@@ -1,5 +1,5 @@
 class Events::EventHistories::EventAttendancesLoyalty < ApplicationLoyalty
   def index?
-    LoyaltyTools.event_accessible?(record.event, user) && !record.resolution.phantom?
+    LoyaltyTools.event_accessible?(record.event, user)
   end
 end

--- a/Vche-rails/app/loyalties/events/event_histories/reschedules_loyalty.rb
+++ b/Vche-rails/app/loyalties/events/event_histories/reschedules_loyalty.rb
@@ -1,5 +1,5 @@
 class Events::EventHistories::ReschedulesLoyalty < ApplicationLoyalty
   def create?
-    LoyaltyTools.user_is_source?(record.event, user)
+    LoyaltyTools.user_is_source?(record.event, user) && !record.resolution.phantom?
   end
 end

--- a/Vche-rails/app/loyalties/events/event_histories/resolutions_loyalty.rb
+++ b/Vche-rails/app/loyalties/events/event_histories/resolutions_loyalty.rb
@@ -1,5 +1,5 @@
 class Events::EventHistories::ResolutionsLoyalty < ApplicationLoyalty
   def update?
-    LoyaltyTools.user_is_source?(record.event, user)
+    LoyaltyTools.user_is_source?(record.event, user) && !record.resolution.phantom?
   end
 end

--- a/Vche-rails/app/loyalties/events/event_histories_loyalty.rb
+++ b/Vche-rails/app/loyalties/events/event_histories_loyalty.rb
@@ -24,7 +24,7 @@ class Events::EventHistoriesLoyalty < ApplicationLoyalty
   end
 
   def destroy?
-    false
+    LoyaltyTools.user_is_source?(record.event, user) && record.persisted?
   end
 
   def attend?

--- a/Vche-rails/app/loyalties/events/event_histories_loyalty.rb
+++ b/Vche-rails/app/loyalties/events/event_histories_loyalty.rb
@@ -8,7 +8,7 @@ class Events::EventHistoriesLoyalty < ApplicationLoyalty
   end
 
   def info?
-    LoyaltyTools.event_accessible?(record.event, user)
+    LoyaltyTools.event_accessible?(record.event, user) && !record.resolution.phantom?
   end
 
   def new?
@@ -28,27 +28,27 @@ class Events::EventHistoriesLoyalty < ApplicationLoyalty
   end
 
   def attend?
-    LoyaltyTools.event_accessible?(record.event, user) && user && !user.attending_event?(record)
+    LoyaltyTools.event_accessible?(record.event, user) && !record.resolution.phantom? && user && !user.attending_event?(record)
   end
 
   def unattend?
-    LoyaltyTools.event_accessible?(record.event, user) && user && user.attending_event_as_audience?(record)
+    LoyaltyTools.event_accessible?(record.event, user) && !record.resolution.phantom? && user && user.attending_event_as_audience?(record)
   end
 
   def add_user?
-    LoyaltyTools.user_is_backstage_member?(record.event, user) && LoyaltyTools.event_allow_backstage?(record.event)
+    LoyaltyTools.user_is_backstage_member?(record.event, user) && !record.resolution.phantom? && LoyaltyTools.event_allow_backstage?(record.event)
   end
 
   def change_user?
-    LoyaltyTools.user_is_backstage_member?(record.event, user) && LoyaltyTools.event_allow_backstage?(record.event)
+    LoyaltyTools.user_is_backstage_member?(record.event, user) && !record.resolution.phantom? && LoyaltyTools.event_allow_backstage?(record.event)
   end
 
   def remove_user?
-    LoyaltyTools.user_is_backstage_member?(record.event, user)
+    LoyaltyTools.user_is_backstage_member?(record.event, user) && !record.resolution.phantom?
   end
 
   def memory?
-    LoyaltyTools.event_accessible?(record.event, user) && user && user.attending_event?(record)
+    LoyaltyTools.event_accessible?(record.event, user) && !record.resolution.phantom? && user && user.attending_event?(record)
   end
 
   concerning :Model do

--- a/Vche-rails/app/loyalties/events/event_histories_loyalty.rb
+++ b/Vche-rails/app/loyalties/events/event_histories_loyalty.rb
@@ -32,7 +32,7 @@ class Events::EventHistoriesLoyalty < ApplicationLoyalty
   end
 
   def unattend?
-    LoyaltyTools.event_accessible?(record.event, user) && !record.resolution.phantom? && user && user.attending_event_as_audience?(record)
+    LoyaltyTools.event_accessible?(record.event, user) && user && user.attending_event_as_audience?(record)
   end
 
   def add_user?
@@ -44,7 +44,7 @@ class Events::EventHistoriesLoyalty < ApplicationLoyalty
   end
 
   def remove_user?
-    LoyaltyTools.user_is_backstage_member?(record.event, user) && !record.resolution.phantom?
+    LoyaltyTools.user_is_backstage_member?(record.event, user)
   end
 
   def memory?

--- a/Vche-rails/app/models/concerns/enums/Resolution.rb
+++ b/Vche-rails/app/models/concerns/enums/Resolution.rb
@@ -11,6 +11,7 @@ module Enums::Resolution
       :canceled,
       :ended,
       :completed,
+      :phantom
     ], default: :information
 
     def resolution_emoji
@@ -28,9 +29,9 @@ module Enums::Resolution
     def resolution.emoji_options(type)
       kwargs =
         case type
-        when :official then {}
-        when :unofficial then  { except: [:scheduled, :announced] }
-        else {}
+        when :official then { except: [:phantom] }
+        when :unofficial then  { except: [:scheduled, :announced, :phantom] }
+        else { except: [:phantom] }
         end
       options(**kwargs).map { |name, value| ["#{Enums::Resolution.resolution_emoji(value)}#{name}", value] }
     end
@@ -55,6 +56,8 @@ module Enums::Resolution
       '✅'
     when :completed
       '📗'
+    when :phantom
+      '🗑'
     else
       '🤔'
     end

--- a/Vche-rails/app/models/event.rb
+++ b/Vche-rails/app/models/event.rb
@@ -142,7 +142,8 @@ class Event < ApplicationRecord
       event: self,
       resolution: :phantom,
       capacity: 0,
-      started_at: start_at
+      started_at: start_at,
+      ended_at: start_at,
     )
   end
 

--- a/Vche-rails/app/models/event.rb
+++ b/Vche-rails/app/models/event.rb
@@ -131,6 +131,10 @@ class Event < ApplicationRecord
       .index_by(&:started_at).values
   end
 
+  def scheduled_at?(time)
+    event_schedules.flat_map { |schedule| schedule.recent_schedule([time]) }.any? { |history| history.started_at == time }
+  end
+
   def find_or_build_history(start_at)
     recent_schedule([start_at.beginning_of_day])
       .detect { |history| history.started_at == start_at} ||

--- a/Vche-rails/app/models/event.rb
+++ b/Vche-rails/app/models/event.rb
@@ -140,7 +140,7 @@ class Event < ApplicationRecord
       .detect { |history| history.started_at == start_at} ||
     EventHistory.new(
       event: self,
-      resolution: :canceled,
+      resolution: :phantom,
       capacity: 0,
       started_at: start_at
     )

--- a/Vche-rails/app/models/event_history.rb
+++ b/Vche-rails/app/models/event_history.rb
@@ -98,6 +98,10 @@ class EventHistory < ApplicationRecord
     started_at&.strftime('%Y%m%d%H%M%S')
   end
 
+  def scheduled?
+    event.scheduled_at?(started_at)
+  end
+
   private
 
   def recalculate_resolution

--- a/Vche-rails/app/models/event_history.rb
+++ b/Vche-rails/app/models/event_history.rb
@@ -39,7 +39,8 @@ class EventHistory < ApplicationRecord
   include Enums::DefaultAudienceRole
 
   validates :event_id, presence: true
-  validates :resolution, unless: :official?, exclusion: { in: %w(scheduled announced), message: "主催のいるイベント用の状態です" }
+  validates :resolution, unless: :official?, exclusion: { in: %w(scheduled announced), message: "は主催のいるイベント用の状態です" }
+  validates :resolution, exclusion: { in: %w(phantom), message: "は選択できない状態です" }
   validates :started_at, presence: true
   validates :ended_at, presence: true
 

--- a/Vche-rails/app/models/operations/event_history/Reschedule.rb
+++ b/Vche-rails/app/models/operations/event_history/Reschedule.rb
@@ -8,6 +8,7 @@ class Operations::EventHistory::Reschedule < Operations::Operation
   end
 
   def validate
+    raise ArgumentError if event_history.resolution.phantom?
     raise Unchanged if event_history.started_at == started_at
   end
 

--- a/Vche-rails/app/presenters/calendar_presenter.rb
+++ b/Vche-rails/app/presenters/calendar_presenter.rb
@@ -102,7 +102,7 @@ class CalendarPresenter
       event_attendances_of_date = event_attendances_by_date[d] || []
       offline_histories_of_date = offline_histories_by_date[d] || []
       trusted_histories = Vche::Trust.filter_trusted(event_histories_of_date)
-      alien_histories = event_attendances_of_date.map { |a| event_histories_of_date.detect { |h| h.event_id == a.event_id } || a.find_or_build_history }.compact
+      alien_histories = event_attendances_of_date.map { |a| event_histories_of_date.detect { |h| h.event_id == a.event_id && h.started_at == a.started_at } || a.find_or_build_history }.compact
       visible_histories = trusted_histories | alien_histories
       h[d] = Cell.new(current_user, d, visible_histories, event_attendances_of_date, offline_histories_of_date)
     end
@@ -176,7 +176,7 @@ class CalendarPresenter
     def initialize(current_user, event_history: nil, offline_history: nil)
       history = event_history || offline_history
       @started_at = history.started_at
-      @ended_at = history.ended_at
+      @ended_at = history.ended_at || history.started_at
       @resolution = ended_at > Time.current ? :information : :ended
       @offset = 0
 

--- a/Vche-rails/app/views/event_histories/_pretty.html.slim
+++ b/Vche-rails/app/views/event_histories/_pretty.html.slim
@@ -42,8 +42,8 @@
       = link_to '編集する', edit_event_event_history_path(event, event_history), class: 'button'
     - if loyalty(event_history, 'events/event_histories').destroy?
       - if event_history.scheduled?
-        = link_to 'リセットする', event_event_history_path(event, event_history), method: :delete, class: 'button -negative'
+        = link_to 'リセットする', event_event_history_path(event, event_history), method: :delete, class: 'button -negative', data: {confirm: "開催回の情報を消去しますか？\n（参加表明や思い出は消去されません。）"}
       - else
-        = link_to '削除する', event_event_history_path(event, event_history), method: :delete, class: 'button -negative'
+        = link_to '削除する', event_event_history_path(event, event_history), method: :delete, class: 'button -negative', data: {confirm: "開催回の情報を消去しますか？\n（参加表明や思い出は消去されません。）"}
 
   = render 'editor_info', resource: event_history

--- a/Vche-rails/app/views/event_histories/_pretty.html.slim
+++ b/Vche-rails/app/views/event_histories/_pretty.html.slim
@@ -37,8 +37,13 @@
 
   .actions
     - if loyalty(event_history, 'events/event_histories').info?
-      = link_to '情報を見る', info_event_event_history_path(@event, @event_history), class: :button
+      = link_to '情報を見る', info_event_event_history_path(event, event_history), class: :button
     - if loyalty(event_history, 'events/event_histories').edit?
       = link_to '編集する', edit_event_event_history_path(event, event_history), class: 'button'
+    - if loyalty(event_history, 'events/event_histories').destroy?
+      - if event_history.scheduled?
+        = link_to 'リセットする', event_event_history_path(event, event_history), method: :delete, class: 'button -negative'
+      - else
+        = link_to '削除する', event_event_history_path(event, event_history), method: :delete, class: 'button -negative'
 
   = render 'editor_info', resource: event_history

--- a/Vche-rails/app/views/event_histories/_table.html.slim
+++ b/Vche-rails/app/views/event_histories/_table.html.slim
@@ -41,5 +41,10 @@
   .actions
     - if loyalty(event_history, 'events/event_histories').edit?
       = link_to '編集する', edit_event_event_history_path(event, event_history), class: 'button'
+    - if loyalty(event_history, 'events/event_histories').destroy?
+      - if event_history.scheduled?
+        = link_to 'リセットする', event_event_history_path(event, event_history), method: :delete, class: 'button -negative'
+      - else
+        = link_to '削除する', event_event_history_path(event, event_history), method: :delete, class: 'button -negative'
 
   = render 'editor_info', resource: event_history

--- a/Vche-rails/app/views/event_histories/_table.html.slim
+++ b/Vche-rails/app/views/event_histories/_table.html.slim
@@ -43,8 +43,8 @@
       = link_to '編集する', edit_event_event_history_path(event, event_history), class: 'button'
     - if loyalty(event_history, 'events/event_histories').destroy?
       - if event_history.scheduled?
-        = link_to 'リセットする', event_event_history_path(event, event_history), method: :delete, class: 'button -negative'
+        = link_to 'リセットする', event_event_history_path(event, event_history), method: :delete, class: 'button -negative', data: {confirm: "開催回の情報を消去しますか？\n（参加表明や思い出は消去されません。）"}
       - else
-        = link_to '削除する', event_event_history_path(event, event_history), method: :delete, class: 'button -negative'
+        = link_to '削除する', event_event_history_path(event, event_history), method: :delete, class: 'button -negative', data: {confirm: "開催回の情報を消去しますか？\n（参加表明や思い出は消去されません。）"}
 
   = render 'editor_info', resource: event_history

--- a/Vche-rails/config/locales/vche.ja.yml
+++ b/Vche-rails/config/locales/vche.ja.yml
@@ -131,6 +131,7 @@ ja:
         canceled: 中止
         ended: 終了
         completed: 完了
+        phantom: 非実在
       role:
         irrelevant: 不参加
         owner: 主催

--- a/Vche-rails/config/locales/vche.notice.ja.yml
+++ b/Vche-rails/config/locales/vche.notice.ja.yml
@@ -28,7 +28,7 @@ ja:
       update:
         success: 'イベントの開催回を更新しました'
       destroy:
-        success: 'EventHistory was successfully destroyed.'
+        success: 'イベントの開催回をクリアしました'
       attend:
         success: 'イベントの開催回に参加しました'
       unattend:


### PR DESCRIPTION
- 削除された開催回は「非実在」という状態で残る
- 削除された開催回に紐づく参加表明はカレンダーに表示される
- 削除された開催回に紐づく思い出にアクセスできる