### PR TITLE
トップページのカレンダーで全ての情報を表示できるようにした

### DIFF
--- a/Vche-rails/app/controllers/calendar_controller.rb
+++ b/Vche-rails/app/controllers/calendar_controller.rb
@@ -4,8 +4,8 @@ class CalendarController < ApplicationController::Bootstrap
   def index
     authorize!
 
-    form = CalendarPresenterForm.new(Event.public_or_over, index_params, filter: true)
-    @calendar = form.presenter(current_user: current_user, candidate: params[:taste] == 'all')
+    @form = CalendarPresenterForm.new(Event.public_or_over, index_params, filter: { trust: 'owner' })
+    @calendar = @form.presenter(current_user: current_user, candidate: params[:taste] == 'all')
   end
 
   private

--- a/Vche-rails/app/controllers/calendar_controller.rb
+++ b/Vche-rails/app/controllers/calendar_controller.rb
@@ -4,14 +4,13 @@ class CalendarController < ApplicationController::Bootstrap
   def index
     authorize!
 
-    scoped_events = Event.public_or_over.where('trust > ?', Event::OWNER_TRUST)
-    form = CalendarPresenterForm.new(scoped_events, index_params, filter: true)
+    form = CalendarPresenterForm.new(Event.public_or_over, index_params, filter: true)
     @calendar = form.presenter(current_user: current_user, candidate: params[:taste] == 'all')
   end
 
   private
 
   def index_params
-    @index_params ||= params.permit(:calendar, :date, :category, :taste)
+    @index_params ||= params.permit(:calendar, :date, :category, :trust, :taste)
   end
 end

--- a/Vche-rails/app/controllers/calendar_controller.rb
+++ b/Vche-rails/app/controllers/calendar_controller.rb
@@ -4,7 +4,7 @@ class CalendarController < ApplicationController::Bootstrap
   def index
     authorize!
 
-    @form = CalendarPresenterForm.new(Event.public_or_over, index_params, filter: { trust: 'owner' })
+    @form = CalendarPresenterForm.new(Event.public_or_over, index_params, filter: { trust: Rails.application.config.x.vche.public_calendar_trust })
     @calendar = @form.presenter(current_user: current_user, candidate: params[:taste] == 'all')
   end
 

--- a/Vche-rails/app/controllers/events_controller.rb
+++ b/Vche-rails/app/controllers/events_controller.rb
@@ -2,7 +2,7 @@ class EventsController < ApplicationController::Bootstrap
   skip_before_action :require_login, only: [:index, :show]
 
   def index
-    @events = Event.public_or_over.with_category_param(params[:category]).with_taste_param(params[:taste]).page(params[:page])
+    @events = Event.public_or_over.with_category_param(params[:category]).with_trust_param(params[:trust]).with_taste_param(params[:taste]).page(params[:page])
     authorize!
   end
 

--- a/Vche-rails/app/controllers/events_controller.rb
+++ b/Vche-rails/app/controllers/events_controller.rb
@@ -2,7 +2,8 @@ class EventsController < ApplicationController::Bootstrap
   skip_before_action :require_login, only: [:index, :show]
 
   def index
-    @events = Event.public_or_over.with_category_param(params[:category]).with_trust_param(params[:trust]).with_taste_param(params[:taste]).page(params[:page])
+    @form = CalendarPresenterForm.new(Event.public_or_over, index_params, filter: { trust: :all }, paginate: true)
+    @events = @form.events
     authorize!
   end
 
@@ -11,8 +12,8 @@ class EventsController < ApplicationController::Bootstrap
     authorize! @event
 
     @user = current_user
-    form = CalendarPresenterForm.new([@event], params)
-    @calendar = form.presenter(current_user: @user, months: 2, candidate: true)
+    @form = CalendarPresenterForm.new([@event], show_params)
+    @calendar = @form.presenter(current_user: @user, months: 2, candidate: true)
   end
 
   def info
@@ -145,7 +146,7 @@ class EventsController < ApplicationController::Bootstrap
   end
 
   def index_params
-    params.permit(:taste)
+    params.permit(:category, :trust, :taste)
   end
 
   def show_params

--- a/Vche-rails/app/controllers/hashtags_controller.rb
+++ b/Vche-rails/app/controllers/hashtags_controller.rb
@@ -16,6 +16,6 @@ class HashtagsController < ApplicationController::Bootstrap
   end
 
   def show_params
-    params.permit(:id, :calendar, :date, :category, :taste)
+    params.permit(:id, :calendar, :date, :category, :trust, :taste)
   end
 end

--- a/Vche-rails/app/controllers/hashtags_controller.rb
+++ b/Vche-rails/app/controllers/hashtags_controller.rb
@@ -9,10 +9,10 @@ class HashtagsController < ApplicationController::Bootstrap
   def show
     authorize!
     scoped_events = Event.public_or_over.where(hashtag: params[:id]).order(trust: :desc)
-    form = CalendarPresenterForm.new(scoped_events, show_params, filter: true, paginate: true)
+    @form = CalendarPresenterForm.new(scoped_events, show_params, filter: { trust: 'all' }, paginate: true)
 
-    @calendar = form.presenter(current_user: current_user, candidate: true)
-    @events = form.events
+    @calendar = @form.presenter(current_user: current_user, candidate: true)
+    @events = @form.events
   end
 
   def show_params

--- a/Vche-rails/app/controllers/home_controller.rb
+++ b/Vche-rails/app/controllers/home_controller.rb
@@ -2,8 +2,8 @@ class HomeController < ApplicationController::Bootstrap
   def show
     authorize!
     @user = current_user
-    form = CalendarPresenterForm.new(@user.following_events, show_params)
-    @calendar = form.presenter(current_user: @user, display_user: @user, candidate: true)
+    @form = CalendarPresenterForm.new(@user.following_events, show_params)
+    @calendar = @form.presenter(current_user: @user, display_user: @user, candidate: true)
   end
 
   def events

--- a/Vche-rails/app/controllers/users_controller.rb
+++ b/Vche-rails/app/controllers/users_controller.rb
@@ -10,8 +10,8 @@ class UsersController < ApplicationController::Bootstrap
     @user = find_user
     authorize! @user
 
-    form = CalendarPresenterForm.new(@user.following_events.invite_or_over, show_params)
-    @calendar = form.presenter(current_user: current_user, display_user: @user, candidate: true)
+    @form = CalendarPresenterForm.new(@user.following_events.invite_or_over, show_params)
+    @calendar = @form.presenter(current_user: current_user, display_user: @user, candidate: true)
   end
 
   def info

--- a/Vche-rails/app/forms/calendar_presenter_form.rb
+++ b/Vche-rails/app/forms/calendar_presenter_form.rb
@@ -31,7 +31,7 @@ class CalendarPresenterForm
     @events ||=
       begin
         events = scoped_events
-        events = events.with_category_param(params[:category]).with_taste_param(params[:taste]) if filter
+        events = events.with_category_param(params[:category]).with_trust_param(params[:trust]).with_taste_param(params[:taste]) if filter
         events = events.page(params[:page]) if paginate
         events
       end

--- a/Vche-rails/app/forms/calendar_presenter_form.rb
+++ b/Vche-rails/app/forms/calendar_presenter_form.rb
@@ -1,11 +1,13 @@
 class CalendarPresenterForm
   attr_reader :scoped_events, :params, :filter, :paginate, :range_mode
 
-  def initialize(scoped_events, params, filter: false, paginate: false)
+  def initialize(scoped_events, filtered_params, filter: false, paginate: false)
     @scoped_events = scoped_events
-    @params = params
+    @params = filtered_params
     @filter = filter
     @paginate = paginate
+
+    @params = @params.reverse_merge(filter.to_h) if filter.respond_to?(:to_h)
   end
 
   def presenter(current_user: nil, display_user: nil, months: 1, candidate: false)

--- a/Vche-rails/app/models/event.rb
+++ b/Vche-rails/app/models/event.rb
@@ -103,6 +103,18 @@ class Event < ApplicationRecord
   # scope :with_category_param, ->(category_param) { category_param.present? ? where(category: Category.find_by(slug: category_param)) : all }
   scope :with_category_param, ->(category_param) { category_param.present? ? joins(:category).where('categories.slug': category_param) : all }
 
+  scope :with_trust_param, ->(trust_param) do
+    puts "trust_param: #{trust_param}"
+    case trust_param.to_s
+    when 'owner'
+      where('trust >= ?', OWNER_TRUST)
+    when 'trusted'
+      where('trust >= ?', 3)
+    else
+      all
+    end
+  end
+
   def recalculate_trust
     trust = 0
     root_trust = 0

--- a/Vche-rails/app/models/event.rb
+++ b/Vche-rails/app/models/event.rb
@@ -104,7 +104,6 @@ class Event < ApplicationRecord
   scope :with_category_param, ->(category_param) { category_param.present? ? joins(:category).where('categories.slug': category_param) : all }
 
   scope :with_trust_param, ->(trust_param) do
-    puts "trust_param: #{trust_param}"
     case trust_param.to_s
     when 'owner'
       where('trust >= ?', OWNER_TRUST)

--- a/Vche-rails/app/views/application/_category_select.html.slim
+++ b/Vche-rails/app/views/application/_category_select.html.slim
@@ -1,4 +1,8 @@
-- category_options = [['開催形態を選ぶ', nil]] + Category.available.map { |c| [c.emoji_name, c.slug] }
+- form ||= nil
 
-= form_with(url: filtered_params, method: :get, class: '-inline') do |form|
-  = form.select :category, category_options, { selected: params[:category] }, onchange: "javascript: this.form.submit();"
+- _params = filtered_params
+- _params.merge!(form.params) if form
+- _category_options = [['開催形態を選ぶ', nil]] + Category.available.map { |c| [c.emoji_name, c.slug] }
+
+= form_with(url: _params, method: :get, class: '-inline') do |form|
+  = form.select :category, _category_options, { selected: _params[:category] }, onchange: "javascript: this.form.submit();"

--- a/Vche-rails/app/views/application/_taste_select.html.slim
+++ b/Vche-rails/app/views/application/_taste_select.html.slim
@@ -1,2 +1,7 @@
-= form_with(url: filtered_params, method: :get, class: '-inline') do |form|
-  = form.select :taste, Enums::Taste.select_options, { selected: params[:taste] }, onchange: "javascript: this.form.submit();"
+- form ||= nil
+
+- _params = filtered_params
+- _params.merge!(form.params) if form
+
+= form_with(url: _params, method: :get, class: '-inline') do |form|
+  = form.select :taste, Enums::Taste.select_options, { selected: _params[:taste] }, onchange: "javascript: this.form.submit();"

--- a/Vche-rails/app/views/application/_trust_select.html.slim
+++ b/Vche-rails/app/views/application/_trust_select.html.slim
@@ -1,0 +1,4 @@
+- trust_options = [['情報源を選ぶ', nil], ['公式告知', :owner], ['全ての情報', :all]]
+
+= form_with(url: filtered_params, method: :get, class: '-inline') do |form|
+  = form.select :trust, trust_options, { selected: params[:trust] }, onchange: "javascript: this.form.submit();"

--- a/Vche-rails/app/views/application/_trust_select.html.slim
+++ b/Vche-rails/app/views/application/_trust_select.html.slim
@@ -1,4 +1,8 @@
-- trust_options = [['情報源を選ぶ', nil], ['公式告知', :owner], ['全ての情報', :all]]
+- form ||= nil
 
-= form_with(url: filtered_params, method: :get, class: '-inline') do |form|
-  = form.select :trust, trust_options, { selected: params[:trust] }, onchange: "javascript: this.form.submit();"
+- _params = filtered_params
+- _params.merge!(form.params) if form
+- _trust_options = [['公式告知', :owner], ['全ての情報', :all]]
+
+= form_with(url: _params, method: :get, class: '-inline') do |form|
+  = form.select :trust, _trust_options, { selected: _params[:trust] }, onchange: "javascript: this.form.submit();"

--- a/Vche-rails/app/views/calendar/_calendar.slim
+++ b/Vche-rails/app/views/calendar/_calendar.slim
@@ -1,23 +1,26 @@
 - calendar ||= nil
-- calendar_params = filtered_params
+- form ||= nil
 - enable_filters ||= false
-- calendar_class = "calendar -cells -#{calendar.format}"
+
+- _calendar_params = filtered_params
+- _calendar_params.merge!(form.params) if form
+- _calendar_class = "calendar -cells -#{calendar.format}"
 
 nav.calendar__nav
   = form_with(url: filtered_params, method: :get, class: '-inline') do |form|
     = form.select :calendar, calendar.options, { selected: params[:calendar] }, onchange: "javascript: this.form.submit();"
-  = link_to("=", calendar_params.except(:date), class: :button)
-  = link_to("< #{calendar.prev_date_text}", calendar_params.merge(date: calendar.prev_date_str), class: :button)
+  = link_to("=", _calendar_params.except(:date), class: :button)
+  = link_to("< #{calendar.prev_date_text}", _calendar_params.merge(date: calendar.prev_date_str), class: :button)
   - unless calendar.current
     span.current = calendar.current_date_text
-  = link_to("#{calendar.next_date_text} >", calendar_params.merge(date: calendar.next_date_str), class: :button)
+  = link_to("#{calendar.next_date_text} >", _calendar_params.merge(date: calendar.next_date_str), class: :button)
   - if enable_filters
-    = render 'category_select'
-    = render 'trust_select'
-    = render 'taste_select'
+    = render 'category_select', form: form
+    = render 'trust_select', form: form
+    = render 'taste_select', form: form
 
 - calendar.cells_by_date.each_slice(7) do |slice|
-  div class=calendar_class
+  div class=_calendar_class
     .calendar__headers
       - slice.each do |date, cell|
         div class=css_class_of_time(date, :calendar__header)

--- a/Vche-rails/app/views/calendar/_calendar.slim
+++ b/Vche-rails/app/views/calendar/_calendar.slim
@@ -13,6 +13,7 @@ nav.calendar__nav
   = link_to("#{calendar.next_date_text} >", calendar_params.merge(date: calendar.next_date_str), class: :button)
   - if enable_filters
     = render 'category_select'
+    = render 'trust_select'
     = render 'taste_select'
 
 - calendar.cells_by_date.each_slice(7) do |slice|

--- a/Vche-rails/app/views/calendar/index.html.slim
+++ b/Vche-rails/app/views/calendar/index.html.slim
@@ -1,3 +1,3 @@
 h1 = 'カレンダー'
 
-= render 'calendar', calendar: @calendar, enable_filters: true
+= render 'calendar', calendar: @calendar, form: @form, enable_filters: true

--- a/Vche-rails/app/views/events/index.html.slim
+++ b/Vche-rails/app/views/events/index.html.slim
@@ -2,6 +2,7 @@ h1 = Event.model_name.human
 
 nav.event__nav
   = render 'category_select'
+  = render 'trust_select'
   = render 'taste_select'
 
 .panel

--- a/Vche-rails/app/views/events/index.html.slim
+++ b/Vche-rails/app/views/events/index.html.slim
@@ -1,9 +1,9 @@
 h1 = Event.model_name.human
 
 nav.event__nav
-  = render 'category_select'
-  = render 'trust_select'
-  = render 'taste_select'
+  = render 'category_select', form: @form
+  = render 'trust_select', form: @form
+  = render 'taste_select', form: @form
 
 .panel
   = render 'cards', events: @events, card_cloud: true

--- a/Vche-rails/app/views/events/show.html.slim
+++ b/Vche-rails/app/views/events/show.html.slim
@@ -2,7 +2,7 @@ h1 = "#{Event.model_name.human}詳細"
 
 = render 'strip', event: @event, user: @user
 
-= render 'calendar/calendar', calendar: @calendar
+= render 'calendar/calendar', calendar: @calendar, form: @form
 
 = render 'pretty', event: @event
 

--- a/Vche-rails/app/views/hashtags/show.html.slim
+++ b/Vche-rails/app/views/hashtags/show.html.slim
@@ -1,13 +1,13 @@
 h1 = "#{Event.human_attribute_name(:hashtag)}から#{Event.model_name.human}を調べる"
 
 nav.event__nav
-  = render 'category_select'
-  = render 'trust_select'
-  = render 'taste_select'
+  = render 'category_select', form: @form
+  = render 'trust_select', form: @form
+  = render 'taste_select', form: @form
 
 .panel
   = render 'events/cards', events: @events, actions: :hashtag
 .panel
   = paginate @events
 
-= render 'calendar/calendar', calendar: @calendar
+= render 'calendar/calendar', calendar: @calendar, form: @form

--- a/Vche-rails/app/views/hashtags/show.html.slim
+++ b/Vche-rails/app/views/hashtags/show.html.slim
@@ -2,6 +2,7 @@ h1 = "#{Event.human_attribute_name(:hashtag)}から#{Event.model_name.human}を�
 
 nav.event__nav
   = render 'category_select'
+  = render 'trust_select'
   = render 'taste_select'
 
 .panel

--- a/Vche-rails/app/views/home/show.html.slim
+++ b/Vche-rails/app/views/home/show.html.slim
@@ -4,7 +4,7 @@ h1 = 'マイページ'
 
 h2 = '自分の予定'
 
-= render 'calendar/calendar', calendar: @calendar
+= render 'calendar/calendar', calendar: @calendar, form: @form
 
 .panel
   .actions

--- a/Vche-rails/app/views/users/show.html.slim
+++ b/Vche-rails/app/views/users/show.html.slim
@@ -2,7 +2,7 @@ h1 = "#{User.model_name.human}詳細"
 
 = render 'strip', user: @user
 
-= render 'calendar/calendar', calendar: @calendar
+= render 'calendar/calendar', calendar: @calendar, form: @form
 
 = render 'pretty', user: @user
 

--- a/Vche-rails/config/application.rb
+++ b/Vche-rails/config/application.rb
@@ -41,6 +41,8 @@ module Vche
 
     config.x.vche.allow_private_backstage = false
 
+    config.x.vche.public_calendar_trust = ENV.fetch('VCHE_PUBLIC_CALENDAR_TRUST') { 'owner' }
+
     config.x.vche.support_email = ENV.fetch('VCHE_SUPPORT_EMAIL') { 'support@example.com' }
     config.x.vche.support_github = ENV.fetch('VCHE_SUPPORT_GITHUB') { 'https://example.com/github' }
     config.x.vche.support_twitter = ENV.fetch('VCHE_SUPPORT_TWITTER') { 'https://example.com/twitter' }

--- a/Vche-rails/docker-compose.override.yml.sample
+++ b/Vche-rails/docker-compose.override.yml.sample
@@ -3,6 +3,7 @@ version: '3.9'
 services:
   app:
     environment:
+      VCHE_PUBLIC_CALENDAR_TRUST: all
       VCHE_SUPPORT_EMAIL: support@example.com
       VCHE_SUPPORT_GITHUB: https://example.com/github
       VCHE_SUPPORT_TWITTER: https://example.com/twitter

--- a/Vche-rails/docker-compose.production.yml
+++ b/Vche-rails/docker-compose.production.yml
@@ -11,6 +11,7 @@ services:
     environment:
       RAILS_ENV: production
       VCHE_ENV: production
+      VCHE_PUBLIC_CALENDAR_TRUST: all
       VCHE_SUPPORT_EMAIL: support@example.com
       VCHE_SUPPORT_GITHUB: https://example.com/github
       VCHE_SUPPORT_TWITTER: https://example.com/twitter


### PR DESCRIPTION
上でそれをデフォルトにすることができるようにしました。

Ref: #80

<img width="967" alt="image" src="https://user-images.githubusercontent.com/4142423/143787809-8ea5cfaf-1bd0-409f-bcfa-8c0647301aa7.png">

当分の間は public_calendar_trust=all 運用になるため、トップページのカレンダーで全ての `公開` 情報が表示されます。
（これはイベント一覧で表示されるものと同じです。）