### PR TITLE
Visibilityのdefault_scopeを外した

### DIFF
--- a/Vche-rails/.rubocop/metrics.yml
+++ b/Vche-rails/.rubocop/metrics.yml
@@ -1,7 +1,7 @@
 # Offense count: 13
 # Configuration parameters: IgnoredMethods, CountRepeatedAttributes.
 Metrics/AbcSize:
-  Max: 98
+  Max: 100
 
 # Offense count: 7
 # Configuration parameters: CountComments, CountAsOne, ExcludedMethods, IgnoredMethods.

--- a/Vche-rails/app/controllers/event_schedules_controller.rb
+++ b/Vche-rails/app/controllers/event_schedules_controller.rb
@@ -58,7 +58,7 @@ class EventSchedulesController < ApplicationController::Bootstrap
   private
 
   def find_parent_event
-    @event = Event.friendly.find(params[:event_id])
+    @event = Event.friendly.secret_or_over.find(params[:event_id])
   end
 
   def find_event_schedule

--- a/Vche-rails/app/controllers/events/event_follow_requests_controller.rb
+++ b/Vche-rails/app/controllers/events/event_follow_requests_controller.rb
@@ -17,6 +17,6 @@ class Events::EventFollowRequestsController < ApplicationController::Bootstrap
   private
 
   def find_parent_event
-    @event = Event.friendly.find(params[:event_id])
+    @event = Event.friendly.secret_or_over.find(params[:event_id])
   end
 end

--- a/Vche-rails/app/controllers/events/event_follows_controller.rb
+++ b/Vche-rails/app/controllers/events/event_follows_controller.rb
@@ -9,6 +9,6 @@ class Events::EventFollowsController < ApplicationController::Bootstrap
   private
 
   def find_parent_event
-    @event = Event.friendly.find(params[:event_id])
+    @event = Event.friendly.secret_or_over.find(params[:event_id])
   end
 end

--- a/Vche-rails/app/controllers/events/event_histories/event_attendances_controller.rb
+++ b/Vche-rails/app/controllers/events/event_histories/event_attendances_controller.rb
@@ -10,7 +10,7 @@ class Events::EventHistories::EventAttendancesController < ApplicationController
   private
 
   def find_parent_event
-    @event = Event.friendly.find(params[:event_id])
+    @event = Event.friendly.secret_or_over.find(params[:event_id])
   end
 
   def find_parent_event_history

--- a/Vche-rails/app/controllers/events/event_histories/reschedules_controller.rb
+++ b/Vche-rails/app/controllers/events/event_histories/reschedules_controller.rb
@@ -18,7 +18,7 @@ class Events::EventHistories::ReschedulesController < ApplicationController::Boo
   private
 
   def find_parent_event
-    @event = Event.friendly.find(params[:event_id])
+    @event = Event.friendly.secret_or_over.find(params[:event_id])
   end
 
   def find_parent_event_history

--- a/Vche-rails/app/controllers/events/event_histories/resolutions_controller.rb
+++ b/Vche-rails/app/controllers/events/event_histories/resolutions_controller.rb
@@ -18,7 +18,7 @@ class Events::EventHistories::ResolutionsController < ApplicationController::Boo
   private
 
   def find_parent_event
-    @event = Event.friendly.find(params[:event_id])
+    @event = Event.friendly.secret_or_over.find(params[:event_id])
   end
 
   def find_parent_event_history

--- a/Vche-rails/app/controllers/events/event_histories_controller.rb
+++ b/Vche-rails/app/controllers/events/event_histories_controller.rb
@@ -135,11 +135,11 @@ class Events::EventHistoriesController < ApplicationController::Bootstrap
   private
 
   def find_user
-    User.friendly.find(params[:user_id])
+    User.friendly.secret_or_over.find(params[:user_id])
   end
 
   def find_parent_event
-    @event = Event.friendly.find(params[:event_id])
+    @event = Event.friendly.secret_or_over.find(params[:event_id])
   end
 
   def find_event_history

--- a/Vche-rails/app/controllers/events/owners_controller.rb
+++ b/Vche-rails/app/controllers/events/owners_controller.rb
@@ -13,7 +13,7 @@ class Events::OwnersController < ApplicationController::Bootstrap
 
   def update
     authorize! @event
-    @user = User.friendly.find(update_params[:owner_id])
+    @user = User.friendly.secret_or_over.find(update_params[:owner_id])
     @user.become_organizer!
     @event.owner = @user
     redirect_to @event, notice: I18n.t('notice.events/owners.update.success')
@@ -22,7 +22,7 @@ class Events::OwnersController < ApplicationController::Bootstrap
   private
 
   def find_parent_event
-    @event = Event.friendly.find(params[:event_id])
+    @event = Event.friendly.secret_or_over.find(params[:event_id])
   end
 
   def update_params

--- a/Vche-rails/app/controllers/events/settings_controller.rb
+++ b/Vche-rails/app/controllers/events/settings_controller.rb
@@ -9,6 +9,6 @@ class Events::SettingsController < ApplicationController::Bootstrap
   private
 
   def find_parent_event
-    @event = Event.friendly.find(params[:event_id])
+    @event = Event.friendly.secret_or_over.find(params[:event_id])
   end
 end

--- a/Vche-rails/app/controllers/events/visibilities_controller.rb
+++ b/Vche-rails/app/controllers/events/visibilities_controller.rb
@@ -23,7 +23,7 @@ class Events::VisibilitiesController < ApplicationController::Bootstrap
   private
 
   def find_parent_event
-    @event = Event.friendly.find(params[:event_id])
+    @event = Event.friendly.secret_or_over.find(params[:event_id])
   end
 
   def update_params

--- a/Vche-rails/app/controllers/events_controller.rb
+++ b/Vche-rails/app/controllers/events_controller.rb
@@ -146,11 +146,11 @@ class EventsController < ApplicationController::Bootstrap
   private
 
   def find_user
-    User.friendly.find(params[:user_id])
+    User.friendly.secret_or_over.find(params[:user_id])
   end
 
   def find_event
-    Event.friendly.find(params[:id])
+    Event.friendly.secret_or_over.find(params[:id])
   end
 
   def index_params

--- a/Vche-rails/app/controllers/users/accounts_controller.rb
+++ b/Vche-rails/app/controllers/users/accounts_controller.rb
@@ -57,7 +57,7 @@ class Users::AccountsController < ApplicationController::Bootstrap
   private
 
   def find_parent_user
-    @user = User.friendly.find(params[:user_id])
+    @user = User.friendly.secret_or_over.find(params[:user_id])
   end
 
   def find_account

--- a/Vche-rails/app/controllers/users/event_memories_controller.rb
+++ b/Vche-rails/app/controllers/users/event_memories_controller.rb
@@ -53,7 +53,7 @@ class Users::EventMemoriesController < ApplicationController::Bootstrap
   private
 
   def find_parent_user
-    @user = User.friendly.find(params[:user_id])
+    @user = User.friendly.secret_or_over.find(params[:user_id])
   end
 
   def find_event_memory
@@ -62,13 +62,13 @@ class Users::EventMemoriesController < ApplicationController::Bootstrap
 
   def new_params
     new_params = params.permit(:user_id, :event_id, :started_at)
-    new_params[:event_id] = Event.friendly.find(new_params[:event_id]).id
+    new_params[:event_id] = Event.friendly.secret_or_over.find(new_params[:event_id]).id
     new_params
   end
 
   def create_params
     create_params = params.require(:event_memory).permit(:event_id, :started_at, :body, :urls)
-    create_params[:event_id] = Event.friendly.find(create_params[:event_id]).id
+    create_params[:event_id] = Event.friendly.secret_or_over.find(create_params[:event_id]).id
     create_params[:urls] = create_params[:urls].each_line.take(100).map(&:strip).to_a.compact
     create_params
   end

--- a/Vche-rails/app/controllers/users_controller.rb
+++ b/Vche-rails/app/controllers/users_controller.rb
@@ -61,7 +61,7 @@ class UsersController < ApplicationController::Bootstrap
   private
 
   def find_user
-    User.friendly.find(params[:id])
+    User.friendly.secret_or_over.find(params[:id])
   end
 
   def show_params

--- a/Vche-rails/app/models/concerns/enums/visibility.rb
+++ b/Vche-rails/app/models/concerns/enums/visibility.rb
@@ -1,21 +1,6 @@
 module Enums::Visibility
   extend ActiveSupport::Concern
 
-  class WarnDefaultScopeHook < String
-    def initialize(value)
-      super(value.to_s)
-    end
-
-    def to_s
-      unless @logged
-        Rails.logger.info 'Using default scope of Enums::Visibility.'
-        Rails.logger.debug { Thread.current.backtrace.grep(/vche/).join("\n") }
-        @logged = true
-      end
-      super
-    end
-  end
-
   included do
     enumerize :visibility, in: [
       :public,
@@ -31,12 +16,6 @@ module Enums::Visibility
     scope :shared_or_over, -> { unscope(where: :visibility).where(visibility: [:public, :shared]) }
     scope :invite_or_over, -> { unscope(where: :visibility).where.not(visibility: [:secret, :deleted]) }
     scope :secret_or_over, -> { unscope(where: :visibility).where.not(visibility: :deleted) }
-
-    if Vche.env.local?
-      default_scope -> { where.not(visibility: WarnDefaultScopeHook.new(:deleted)) }
-    else
-      default_scope -> { secret_or_over }
-    end
 
     def visible?
       self.class.visible_visibility?(visibility)

--- a/Vche-rails/app/models/concerns/enums/visibility.rb
+++ b/Vche-rails/app/models/concerns/enums/visibility.rb
@@ -9,7 +9,7 @@ module Enums::Visibility
     def to_s
       unless @logged
         Rails.logger.info 'Using default scope of Enums::Visibility.'
-        # Rails.logger.debug { Thread.current.backtrace.join("\n") }
+        Rails.logger.debug { Thread.current.backtrace.grep(/vche/).join("\n") }
         @logged = true
       end
       super

--- a/Vche-rails/app/models/concerns/vche/editor_fields.rb
+++ b/Vche-rails/app/models/concerns/vche/editor_fields.rb
@@ -2,7 +2,7 @@ module Vche::EditorFields
   extend ActiveSupport::Concern
 
   included do
-    belongs_to :created_user, class_name: 'User', optional: true
-    belongs_to :updated_user, class_name: 'User', optional: true
+    belongs_to :created_user, -> { invite_or_over }, class_name: 'User', optional: true, inverse_of: "created_#{table_name}"
+    belongs_to :updated_user, -> { invite_or_over }, class_name: 'User', optional: true, inverse_of: "updated_#{table_name}"
   end
 end

--- a/Vche-rails/app/models/concerns/vche/scopes/event_scopes.rb
+++ b/Vche-rails/app/models/concerns/vche/scopes/event_scopes.rb
@@ -1,0 +1,7 @@
+module Vche::Scopes::EventScopes
+  extend ActiveSupport::Concern
+
+  included do
+    scope :secret_event_or_over, -> { joins(:event).merge(Event.secret_or_over) }
+  end
+end

--- a/Vche-rails/app/models/concerns/vche/scopes/user_scopes.rb
+++ b/Vche-rails/app/models/concerns/vche/scopes/user_scopes.rb
@@ -1,0 +1,7 @@
+module Vche::Scopes::UserScopes
+  extend ActiveSupport::Concern
+
+  included do
+    scope :secret_user_or_over, -> { joins(:user).merge(User.secret_or_over) }
+  end
+end

--- a/Vche-rails/app/models/event.rb
+++ b/Vche-rails/app/models/event.rb
@@ -73,22 +73,22 @@ class Event < ApplicationRecord
   has_many :event_schedules, dependent: :destroy
   has_many :event_histories, dependent: :destroy
 
-  has_many :event_follow_requests, dependent: :destroy
+  has_many :all_event_follow_requests, class_name: 'EventFollowRequest', dependent: :destroy
+  has_many :event_follow_requests, -> { secret_user_or_over }, dependent: nil, inverse_of: :event
   has_many :follow_requesters, through: :event_follow_requests, source: :user
 
-  has_many :event_follows, dependent: :destroy
+  has_many :all_event_follows, class_name: 'EventFollow', dependent: :destroy
+  has_many :event_follows, -> { secret_user_or_over }, dependent: nil, inverse_of: :event
   has_many :followers, through: :event_follows, source: :user
-
-  has_many :event_owners, -> { owned }, class_name: 'EventFollow', dependent: nil, inverse_of: :event
+  has_many :event_owners, -> { owned.secret_user_or_over }, class_name: 'EventFollow', dependent: nil, inverse_of: :event
   has_many :owners, through: :event_owners, source: :user
-
-  has_many :event_backstage_members, -> { backstage_member }, class_name: 'EventFollow', dependent: nil, inverse_of: :event
+  has_many :event_backstage_members, -> { backstage_member.secret_user_or_over }, class_name: 'EventFollow', dependent: nil, inverse_of: :event
   has_many :backstage_members, through: :event_backstage_members, source: :user
-
-  has_many :event_audiences, -> { audience }, class_name: 'EventFollow', dependent: nil, inverse_of: :event
+  has_many :event_audiences, -> { audience.secret_user_or_over }, class_name: 'EventFollow', dependent: nil, inverse_of: :event
   has_many :audiences, through: :event_audiences, source: :user
 
-  has_many :event_attendances, dependent: :destroy
+  has_many :all_event_attendances, class_name: 'EventAttendance', dependent: :destroy
+  has_many :event_attendances, -> { secret_user_or_over }, dependent: nil, inverse_of: :event
 
   has_many :event_memories, dependent: :destroy
 

--- a/Vche-rails/app/models/event_attendance.rb
+++ b/Vche-rails/app/models/event_attendance.rb
@@ -27,6 +27,9 @@
 class EventAttendance < ApplicationRecord
   include Vche::Uid
 
+  include Vche::Scopes::UserScopes
+  include Vche::Scopes::EventScopes
+
   include Enums::Role
 
   belongs_to :user

--- a/Vche-rails/app/models/event_follow.rb
+++ b/Vche-rails/app/models/event_follow.rb
@@ -23,6 +23,9 @@
 class EventFollow < ApplicationRecord
   include Enums::Role
 
+  include Vche::Scopes::UserScopes
+  include Vche::Scopes::EventScopes
+
   belongs_to :user
   belongs_to :event
 

--- a/Vche-rails/app/models/event_follow_request.rb
+++ b/Vche-rails/app/models/event_follow_request.rb
@@ -32,6 +32,9 @@
 class EventFollowRequest < ApplicationRecord
   include Enums::Role
 
+  include Vche::Scopes::UserScopes
+  include Vche::Scopes::EventScopes
+
   include Vche::Uid
   include Vche::UidQuery
 

--- a/Vche-rails/app/models/event_memory.rb
+++ b/Vche-rails/app/models/event_memory.rb
@@ -32,8 +32,8 @@ class EventMemory < ApplicationRecord
   include Vche::UidQuery
   include Vche::Hashtag
 
-  belongs_to :user, optional: true
-  belongs_to :event, optional: true
+  belongs_to :user, -> { secret_or_over }, optional: true, inverse_of: :event_memories
+  belongs_to :event, -> { secret_or_over }, optional: true, inverse_of: :event_memories
 
   validates :started_at, presence: true
   validates :published_at, presence: true

--- a/Vche-rails/app/models/user.rb
+++ b/Vche-rails/app/models/user.rb
@@ -71,20 +71,23 @@ class User < ApplicationRecord
   has_many :created_event_histories, class_name: 'EventHistory', foreign_key: :created_user_id, dependent: :nullify, inverse_of: :created_user
   has_many :updated_event_histories, class_name: 'EventHistory', foreign_key: :updated_user_id, dependent: :nullify, inverse_of: :updated_user
 
-  has_many :event_follow_requests, dependent: :destroy
+  has_many :all_event_follow_requests, class_name: 'EventFollowRequest', dependent: :destroy
+  has_many :event_follow_requests, -> { secret_event_or_over }, dependent: nil, inverse_of: :event
   has_many :follow_requesting_events, through: :event_follow_requests, source: :event
 
-  has_many :event_follows, dependent: :destroy
+  has_many :all_event_follows, dependent: :destroy
+  has_many :event_follows, -> { secret_event_or_over }, dependent: nil, inverse_of: :user
   has_many :following_events, through: :event_follows, source: :event
-
-  has_many :owned_follows, -> { owned }, class_name: 'EventFollow', dependent: nil, inverse_of: :user
+  has_many :owned_follows, -> { owned.secret_event_or_over }, class_name: 'EventFollow', dependent: nil, inverse_of: :user
   has_many :owned_events, through: :owned_follows, source: :event
-  has_many :backstage_follows, -> { backstage_member }, class_name: 'EventFollow', dependent: nil, inverse_of: :user
+  has_many :backstage_follows, -> { backstage_member.secret_event_or_over }, class_name: 'EventFollow', dependent: nil, inverse_of: :user
   has_many :backstage_events, through: :backstage_follows, source: :event
-  has_many :audience_follows, -> { audience }, class_name: 'EventFollow', dependent: nil, inverse_of: :user
+  has_many :audience_follows, -> { audience.secret_event_or_over }, class_name: 'EventFollow', dependent: nil, inverse_of: :user
   has_many :audience_events, through: :audience_follows, source: :event
 
-  has_many :event_attendances, dependent: :destroy
+  has_many :all_event_attendances, class_name: 'EventAttendance', dependent: :destroy
+  has_many :event_attendances, -> { secret_event_or_over }, dependent: nil, inverse_of: :event
+  has_many :attending_events, through: :event_attendances, source: :event
 
   has_many :offline_schedules, dependent: :destroy
 

--- a/Vche-rails/app/presenters/calendar_presenter.rb
+++ b/Vche-rails/app/presenters/calendar_presenter.rb
@@ -82,7 +82,7 @@ class CalendarPresenter
       if display_user
         # FIXME: Ideally we should also collect current_user.event_attendances
         display_user.event_attendances
-          .joins(:event) # this enables default scope somehow
+          .joins(:event).merge(Event.secret_or_over)
           .where(started_at: beginning_of_calendar...(beginning_of_calendar + days.days))
           .group_by { |ea| ea.started_at.beginning_of_day }
       else

--- a/Vche-rails/app/views/hashtags/_event_cards.html.slim
+++ b/Vche-rails/app/views/hashtags/_event_cards.html.slim
@@ -1,7 +1,7 @@
 - hashtag ||= nil
 
 - if hashtag.present? && hashtag != '#'
-  - _events = Event.where(hashtag: hashtag).order(trust: :desc).limit(5).to_a
+  - _events = Event.where(hashtag: hashtag).secret_or_over.order(trust: :desc).limit(5).to_a
   - if _events.count > 1
     h2 = "関連イベント #{hashtag}"
     .panel


### PR DESCRIPTION
Close #93

Controllerとリレーションにscopeを書くだけでなんとかなるのであればdefault_scopeを外すリスクも低いでしょうということで（引き換えにhas_manyの定義がすごいことになっている）

※Vcheはdefault_scopeを外すメリットが少ない