### PR TITLE
ユーザーの論理削除を実装した

### DIFF
--- a/Vche-rails/app/controllers/application_controller.rb
+++ b/Vche-rails/app/controllers/application_controller.rb
@@ -22,9 +22,18 @@ class ApplicationController < ActionController::Base
   class Bootstrap < ApplicationController
     layout 'application_bootstrap'
 
+    before_action :require_existing_user
     before_action :require_agreement
 
     private
+
+    def require_existing_user
+      return unless current_user
+
+      if current_user.visibility.deleted?
+        redirect_to new_recovery_path
+      end
+    end
 
     def require_agreement
       return unless current_user

--- a/Vche-rails/app/controllers/my/users_controller.rb
+++ b/Vche-rails/app/controllers/my/users_controller.rb
@@ -3,11 +3,13 @@ class My::UsersController < ApplicationController::Bootstrap
 
   def delete
     authorize!
-    Operations::User::Destroy.new(user: current_user, confirm: params[:confirm]).perform!
+    Operations::User::Delete.new(user: current_user, confirm: params[:confirm]).perform!
+    invalidate_active_sessions!
+    logout
     redirect_to :root, notice: I18n.t('notice.my/users.delete.success')
-  rescue Operations::User::Destroy::Confirm
+  rescue Operations::User::Delete::Confirm
     redirect_to my_settings_path, notice: I18n.t('notice.my/users.delete.confirm')
-  rescue Operations::User::Destroy::UserIsOwner
+  rescue Operations::User::Delete::UserIsOwner
     redirect_to my_settings_path
   end
 end

--- a/Vche-rails/app/controllers/my/users_controller.rb
+++ b/Vche-rails/app/controllers/my/users_controller.rb
@@ -1,6 +1,10 @@
 class My::UsersController < ApplicationController::Bootstrap
   include MyResources
 
+  def delete_form
+    authorize!
+  end
+
   def delete
     authorize!
     Operations::User::Delete.new(user: current_user, confirm: params[:confirm]).perform!

--- a/Vche-rails/app/controllers/recoveries_controller.rb
+++ b/Vche-rails/app/controllers/recoveries_controller.rb
@@ -1,0 +1,27 @@
+class RecoveriesController < ApplicationController::Bootstrap
+  include MyResources
+
+  skip_before_action :require_existing_user
+
+  before_action :require_deleted_user
+
+  def new
+    authorize!
+  end
+
+  def create
+    authorize!
+    current_user.update!(visibility: :public)
+    redirect_to home_path
+  end
+
+  private
+
+  def require_deleted_user
+    return unless current_user
+
+    unless current_user.visibility.deleted?
+      redirect_to home_path
+    end
+  end
+end

--- a/Vche-rails/app/controllers/sessions_controller.rb
+++ b/Vche-rails/app/controllers/sessions_controller.rb
@@ -1,5 +1,6 @@
 class SessionsController < ApplicationController::Bootstrap
   skip_before_action :require_login, only: [:new, :create]
+  skip_before_action :require_existing_user
   skip_before_action :require_agreement
 
   def new

--- a/Vche-rails/app/loyalties/my/users_loyalty.rb
+++ b/Vche-rails/app/loyalties/my/users_loyalty.rb
@@ -1,4 +1,8 @@
 class My::UsersLoyalty < ApplicationLoyalty
+  def delete_form?
+    true
+  end
+
   def delete?
     user.owned_events.empty?
   end

--- a/Vche-rails/app/loyalties/recoveries_loyalty.rb
+++ b/Vche-rails/app/loyalties/recoveries_loyalty.rb
@@ -1,0 +1,9 @@
+class RecoveriesLoyalty < ApplicationLoyalty
+  def new?
+    true
+  end
+
+  def create?
+    true
+  end
+end

--- a/Vche-rails/app/models/operations/user/delete.rb
+++ b/Vche-rails/app/models/operations/user/delete.rb
@@ -1,4 +1,4 @@
-class Operations::User::Destroy
+class Operations::User::Delete
   include Operations::Operation
 
   class UserIsOwner < StandardError; end
@@ -15,8 +15,7 @@ class Operations::User::Destroy
   end
 
   def perform
-    @user.visibility = :deleted
-    @user.save!(context: :destroy)
+    user.destroy!
   end
 
   private

--- a/Vche-rails/app/models/user.rb
+++ b/Vche-rails/app/models/user.rb
@@ -55,7 +55,7 @@ class User < ApplicationRecord
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
 
   validates :email, uniqueness: true, presence: true
-  validates :visibility, inclusion: { in: %w[public], message: 'を絞ったユーザーは未実装です' }
+  validates :visibility, unless: -> { validation_context == :destroy }, inclusion: { in: %w[public], message: 'を絞ったユーザーは未実装です' }
 
   validates :display_name, length: { in: 1..31 }
   validates :bio, length: { in: 0..4095 }, allow_blank: true

--- a/Vche-rails/app/views/my/settings/show.html.slim
+++ b/Vche-rails/app/views/my/settings/show.html.slim
@@ -11,26 +11,9 @@ h2 = 'セキュリティ'
     - if loyalty(nil, :sessions).purge?
       = link_to '全てのセッションをログアウト', purge_sessions_path, method: :post, class: 'button', data: {confirm: '全てのセッションをログアウトしますか？'}
 
-h2 = 'アカウント'
+h2 = '利用登録の解除'
 
 .panel.-roundbox
-  h3 利用登録の解除
-  ul
-    li ユーザーと、ユーザーに紐づく情報を恒久的に削除します。これは復活できません。
-    li ユーザーが作成したイベントは削除されません。事前にイベントを非公開にするか、イベントの削除をしてください。
-    li 主催しているイベントを持っているユーザーは削除できません。先に他のユーザーにイベントの主催を移譲するか、イベントの削除をしてください。
-    li
-      | 本当に削除する場合は、確認欄に半角小文字で
-      '
-      code delete
-      '
-      | と入力してください。
-  - if loyalty(nil, 'my/users').delete?
-    .actions
-      = form_with(url: delete_my_user_path, method: :post, class: '-inline') do |form|
-        = render_field form, :confirm, label: '確認' do
-          = form.text_field :confirm
-        = form.submit '利用登録を解除する', class: '-negative', data: {confirm: "本当に利用登録を解除しますか？\nユーザー情報が削除されます。これは復旧できません。"}
-  - else
-    p.inline.-negative イベントを主催しているため、利用登録を解除できません。
-
+  .actions
+    - if loyalty(nil, 'my/users').delete_form?
+      = link_to '利用登録を解除する', delete_form_my_user_path, class: 'button'

--- a/Vche-rails/app/views/my/users/delete_form.html.slim
+++ b/Vche-rails/app/views/my/users/delete_form.html.slim
@@ -1,0 +1,26 @@
+h1 = '自分の設定'
+
+= render 'my/user_strip', user: @user
+
+h2 = '利用登録の解除'
+
+.panel.-roundbox
+  ul
+    li ユーザーと、ユーザーに紐づく情報を恒久的に削除します。これらは復活できません。
+    li あなたが作成したイベントは削除されずに残ります。必要な場合は、事前にイベントを非公開にするか、イベントの削除をしてください。
+    li 主催しているイベントを持っているユーザーは削除できません。先に他のユーザーにイベントの主催を移譲するか、イベントの削除をしてください。
+    li
+      | 本当に削除する場合は、確認欄に半角小文字で
+      '
+      code delete
+      '
+      | と入力してください。
+  - if loyalty(nil, 'my/users').delete?
+    .actions
+      = form_with(url: delete_my_user_path, method: :post, class: '-inline') do |form|
+        = render_field form, :confirm, label: '確認' do
+          = form.text_field :confirm
+        = form.submit '利用登録を解除する', class: '-negative', data: {confirm: "本当に利用登録を解除しますか？\nユーザー情報が削除されます。これは復旧できません。"}
+  - else
+    p.inline.-negative イベントを主催しているため、利用登録を解除できません。
+

--- a/Vche-rails/app/views/recoveries/new.html.slim
+++ b/Vche-rails/app/views/recoveries/new.html.slim
@@ -3,8 +3,8 @@ h1 = "削除された#{User.model_name.human}"
 = render 'my/user_strip', user: @user
 
 .panel.-roundbox
-  p アカウントは削除されています。
+  p このユーザーは現在無効化されています。
 
-  p アカウントを復旧する場合は、以下のボタンをクリックしてください。
+  p ユーザーを復旧する場合は、以下のボタンをクリックしてください。
   .actions
-    = link_to 'アカウントを復旧する', recovery_path, method: :post, class: 'button -positive'
+    = link_to 'ユーザーを復旧する', recovery_path, method: :post, class: 'button -positive'

--- a/Vche-rails/app/views/recoveries/new.html.slim
+++ b/Vche-rails/app/views/recoveries/new.html.slim
@@ -1,0 +1,10 @@
+h1 = "削除された#{User.model_name.human}"
+
+= render 'my/user_strip', user: @user
+
+.panel.-roundbox
+  p アカウントは削除されています。
+
+  p アカウントを復旧する場合は、以下のボタンをクリックしてください。
+  .actions
+    = link_to 'アカウントを復旧する', recovery_path, method: :post, class: 'button -positive'

--- a/Vche-rails/config/routes.rb
+++ b/Vche-rails/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
     end
 
     resource :user do
+      get :delete_form
       post :delete
     end
 

--- a/Vche-rails/config/routes.rb
+++ b/Vche-rails/config/routes.rb
@@ -97,6 +97,8 @@ Rails.application.routes.draw do
     end
   end
 
+  resource :recovery, only: [:new, :create]
+
   resources :feedbacks, only: [:new, :create] do
     collection do
       get :done


### PR DESCRIPTION
あなたの予想に反し、この機能は使われていません（！）

Twitterのアカウントを盗まれた時点でユーザー削除よりひどいことが起こるでしょう、そしてそれをロールバックする手段は現在のVcheには存在しないでしょうということで、とりあえずはユーザーは直ちに削除でよさそうという感じになりました。

機能としては入れるのが難しくなさそうだったので入れておきました（将来的に論理削除を併用する可能性はあるし、今の段階でも管理用に使う機会はありそう）